### PR TITLE
Update back_link.html

### DIFF
--- a/layouts/partials/back_link.html
+++ b/layouts/partials/back_link.html
@@ -1,1 +1,1 @@
-<a href="{{ "/" | relURL }}">{{ $.Site.Params.theme_config.back_home_text }}</a>
+<a href="{{ "" | relURL }}">{{ $.Site.Params.theme_config.back_home_text }}</a>


### PR DESCRIPTION
Reference for [relURL](https://gohugo.io/functions/relurl/)

With a `/`, the back link doesn't work if the `baseURL` has a subdirectory, for example `baseURL = https://example.com/docs/`. Removing the slash and keeping just `""` as a `relURL` fixes this issue, and the back link accurately points to the `baseURL`.